### PR TITLE
Use openresty (alpine) as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,4 @@
-FROM debian:jessie
-
-RUN apt-get update && apt-get -y install wget build-essential libreadline-dev libncurses5-dev libpcre3-dev libssl-dev && apt-get -q -y clean
-RUN wget http://openresty.org/download/ngx_openresty-1.7.10.1.tar.gz \
-  && tar xvfz ngx_openresty-1.7.10.1.tar.gz \
-  && cd ngx_openresty-1.7.10.1 \
-  && ./configure --with-luajit --with-http_gzip_static_module  --with-http_ssl_module \
-  && make \
-  && make install \
-  && rm -rf /ngx_openresty*
+FROM openresty/openresty:1.11.2.5-alpine
 
 EXPOSE 8080
-CMD /usr/local/openresty/nginx/sbin/nginx
-
 ADD nginx.conf /usr/local/openresty/nginx/conf/nginx.conf

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [nginx-echo-headers](https://requestheaders.diddyinc.com/)
+# [nginx-echo-headers](https://diddyinc.com/)
 
 A simple tool for debugging HTTP requests. nginx will return all request headers and body to the client.
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,4 +1,3 @@
-daemon off;
 error_log stderr debug;
 
 events {


### PR DESCRIPTION
Hi Brenden,

I've been using your nginx-echo-headers docker image extensively, but I found that the Docker image was quite large. Openresty also provides an Alpine version of the image. Using it shrinks the image down quite a lot:
```
REPOSITORY                       TAG                 IMAGE ID            CREATED             SIZE
topdesk/echo-headers             latest              86d84ab6eb37        3 minutes ago       46.3MB
brndnmtthws/nginx-echo-headers   latest              1bee060a91aa        13 months ago       388MB
```