### PR TITLE
Allow running container as arbitrary user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,3 +2,7 @@ FROM openresty/openresty:1.11.2.5-alpine
 
 EXPOSE 8080
 ADD nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+
+RUN chgrp -R 0 /usr/local/openresty/nginx/ && \
+    chmod -R g=u /usr/local/openresty/nginx/
+


### PR DESCRIPTION
Hi,
this PR changes ownership of the nginx installation to allow any user access. This is important for container orchestration platforms that expect images to not run with root user for security reasons.